### PR TITLE
Fixes the spanish translation

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,4 @@
-en:
+es:
   actor:
     name: "Nombre"
   avatar:


### PR DESCRIPTION
hi, 

upgrading social stream I noticed the spanish strings appeared instead of the english ones for the avatars for rails labels, actually the new es.yml had "en"  as the lang key, this commit fixes that 
