### PR TITLE
Explicitly close the precropped file before removing

### DIFF
--- a/app/models/avatar.rb
+++ b/app/models/avatar.rb
@@ -50,7 +50,9 @@ class Avatar < ActiveRecord::Base
     make_precrop(precrop_path,@crop_x.to_i,@crop_y.to_i,@crop_w.to_i,@crop_h.to_i)
 
     self.name = @name
-    self.logo = File.open(precrop_path)
+    precropped = File.open(precrop_path)
+    self.logo = precropped
+    precropped.close
 
     FileUtils.remove_file(precrop_path)
   end


### PR DESCRIPTION
When an uploaded file is cropped and the result is assigned to the avatarable's logo, remove_file is done on a still open handle. While this may be OK on *NIX, Windows raises an exception:

```
Errno::EACCES (Permission denied - c:/work/gigtrip/gigtrip-web/gigtrip/public/system/tmp/457312-transcendentone_large201
21113-8352-685h0i.jpg):
  C:/soft/Ruby193/lib/ruby/1.9.1/fileutils.rb:1406:in `unlink'
  C:/soft/Ruby193/lib/ruby/1.9.1/fileutils.rb:1406:in `block in remove_file'
  C:/soft/Ruby193/lib/ruby/1.9.1/fileutils.rb:1414:in `platform_support'
  C:/soft/Ruby193/lib/ruby/1.9.1/fileutils.rb:1405:in `remove_file'
  C:/soft/Ruby193/lib/ruby/1.9.1/fileutils.rb:785:in `remove_file'
  avatars_for_rails (0.2.8) app/models/avatar.rb:55:in `precrop_done'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `_run__250708321__validation__842523070__callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.8) lib/active_support/callbacks.rb:385:in `_run_validation_callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:81:in `run_callbacks'
  activemodel (3.2.8) lib/active_model/validations/callbacks.rb:53:in `run_validations!'
  activemodel (3.2.8) lib/active_model/validations.rb:194:in `valid?'
  activerecord (3.2.8) lib/active_record/validations.rb:69:in `valid?'
  activerecord (3.2.8) lib/active_record/validations.rb:77:in `perform_validations'
  activerecord (3.2.8) lib/active_record/validations.rb:50:in `save'
  activerecord (3.2.8) lib/active_record/attribute_methods/dirty.rb:22:in `save'
  activerecord (3.2.8) lib/active_record/transactions.rb:241:in `block (2 levels) in save'
  activerecord (3.2.8) lib/active_record/transactions.rb:295:in `block in with_transaction_returning_status'
  activerecord (3.2.8) lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
  activerecord (3.2.8) lib/active_record/transactions.rb:208:in `transaction'
  activerecord (3.2.8) lib/active_record/transactions.rb:293:in `with_transaction_returning_status'
  activerecord (3.2.8) lib/active_record/transactions.rb:241:in `block in save'
  activerecord (3.2.8) lib/active_record/transactions.rb:252:in `rollback_active_record_state!'
  activerecord (3.2.8) lib/active_record/transactions.rb:240:in `save'
  activerecord (3.2.8) lib/active_record/associations/has_many_association.rb:16:in `insert_record'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:434:in `block (2 levels) in create_recor
d'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:342:in `add_to_target'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:432:in `block in create_record'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:149:in `block in transaction'
  activerecord (3.2.8) lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
  activerecord (3.2.8) lib/active_record/transactions.rb:208:in `transaction'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:148:in `transaction'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:431:in `create_record'
  activerecord (3.2.8) lib/active_record/associations/collection_association.rb:119:in `create'
  C:in `create'
  avatars_for_rails (0.2.8) app/controllers/avatars_controller.rb:64:in `create'
  actionpack (3.2.8) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  actionpack (3.2.8) lib/abstract_controller/base.rb:167:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (3.2.8) lib/abstract_controller/callbacks.rb:18:in `block in process_action'
  activesupport (3.2.8) lib/active_support/callbacks.rb:447:in `_run__615602833__process_action__544550977__callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.8) lib/active_support/callbacks.rb:385:in `_run_process_action_callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.8) lib/abstract_controller/callbacks.rb:17:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
  activesupport (3.2.8) lib/active_support/notifications.rb:123:in `block in instrument'
  activesupport (3.2.8) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (3.2.8) lib/active_support/notifications.rb:123:in `instrument'
  actionpack (3.2.8) lib/action_controller/metal/instrumentation.rb:29:in `process_action'
  actionpack (3.2.8) lib/action_controller/metal/params_wrapper.rb:207:in `process_action'
  activerecord (3.2.8) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (3.2.8) lib/abstract_controller/base.rb:121:in `process'
  actionpack (3.2.8) lib/abstract_controller/rendering.rb:45:in `process'
  actionpack (3.2.8) lib/action_controller/metal.rb:203:in `dispatch'
  actionpack (3.2.8) lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
  actionpack (3.2.8) lib/action_controller/metal.rb:246:in `block in action'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:73:in `call'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:36:in `call'
  journey (1.0.4) lib/journey/router.rb:68:in `block in call'
  journey (1.0.4) lib/journey/router.rb:56:in `each'
  journey (1.0.4) lib/journey/router.rb:56:in `call'
  actionpack (3.2.8) lib/action_dispatch/routing/route_set.rb:600:in `call'
  omniauth (1.0.3) lib/omniauth/strategy.rb:168:in `call!'
  omniauth (1.0.3) lib/omniauth/strategy.rb:148:in `call'
  omniauth (1.0.3) lib/omniauth/strategy.rb:168:in `call!'
  omniauth (1.0.3) lib/omniauth/strategy.rb:148:in `call'
  mongoid (3.0.11) lib/rack/mongoid/middleware/identity_map.rb:34:in `call'
  warden (1.2.1) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.1) lib/warden/manager.rb:34:in `catch'
  warden (1.2.1) lib/warden/manager.rb:34:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
  rack (1.4.1) lib/rack/etag.rb:23:in `call'
  rack (1.4.1) lib/rack/conditionalget.rb:35:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/head.rb:14:in `call'
  remotipart (1.0.2) lib/remotipart/middleware.rb:30:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/flash.rb:242:in `call'
  rack (1.4.1) lib/rack/session/abstract/id.rb:205:in `context'
  rack (1.4.1) lib/rack/session/abstract/id.rb:200:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/cookies.rb:339:in `call'
  activerecord (3.2.8) lib/active_record/query_cache.rb:64:in `call'
  activerecord (3.2.8) lib/active_record/connection_adapters/abstract/connection_pool.rb:473:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `_run__412746399__call__842523070__callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.8) lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
  activesupport (3.2.8) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.8) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/reloader.rb:65:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
  railties (3.2.8) lib/rails/rack/logger.rb:26:in `call_app'
  railties (3.2.8) lib/rails/rack/logger.rb:16:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/request_id.rb:22:in `call'
  rack (1.4.1) lib/rack/methodoverride.rb:21:in `call'
  rack (1.4.1) lib/rack/runtime.rb:17:in `call'
  activesupport (3.2.8) lib/active_support/cache/strategy/local_cache.rb:72:in `call'
  rack (1.4.1) lib/rack/lock.rb:15:in `call'
  actionpack (3.2.8) lib/action_dispatch/middleware/static.rb:62:in `call'
  railties (3.2.8) lib/rails/engine.rb:479:in `call'
  railties (3.2.8) lib/rails/application.rb:223:in `call'
  rack (1.4.1) lib/rack/content_length.rb:14:in `call'
  railties (3.2.8) lib/rails/rack/log_tailer.rb:17:in `call'
  rack (1.4.1) lib/rack/handler/webrick.rb:59:in `service'
  C:/soft/Ruby193/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
  C:/soft/Ruby193/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
  C:/soft/Ruby193/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
```
